### PR TITLE
Add support for c7n-org extension

### DIFF
--- a/.github/workflows/custodian.yml
+++ b/.github/workflows/custodian.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           include-azure: true
           include-gcp: true
+          include-c7n-org: true
       - name: Run
         run: |
           custodian schema

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   include-gcp:
     description: "Installs the c7n_gcp extension if set to true"
     default: false
+  include-c7n-org: 
+    description: "Installs the c7n-org extension if set to true"
+    default: false
+
 runs:
   using: "composite"
   steps:
@@ -30,6 +34,9 @@ runs:
       fi
       if [ "${{ inputs.include-gcp }}" == true ]; then
         pip install -Iv c7n_gcp"${VERSION_ARG}"
+      fi
+      if [ "${{ inputs.include-c7n-org }}" == true ]; then
+        pip install -Iv c7n-org"${VERSION_ARG}
       fi
       dir=$(pwd)
       cat << EOF > /usr/local/bin/custodian

--- a/action.yml
+++ b/action.yml
@@ -30,13 +30,13 @@ runs:
       fi
       pip install -Iv c7n"${VERSION_ARG}"
       if [ "${{ inputs.include-azure }}" == true ]; then
-        pip install -Iv c7n_azure"${VERSION_ARG}"
+        pip install c7n_azure
       fi
       if [ "${{ inputs.include-gcp }}" == true ]; then
-        pip install -Iv c7n_gcp"${VERSION_ARG}"
+        pip install c7n_gcp
       fi
       if [ "${{ inputs.include-c7n-org }}" == true ]; then
-        pip install -Iv c7n-org"${VERSION_ARG}
+        pip install c7n-org
       fi
       dir=$(pwd)
       cat << EOF > /usr/local/bin/custodian


### PR DESCRIPTION
Adds the `include-c7n-org` option.
Removes the version argument from the extensions because they have separate versions from c7n.
Signed-off-by: Gregory Schofield <gscho@github.com>